### PR TITLE
[alexlist] add support for ED25519 keys

### DIFF
--- a/safekeep
+++ b/safekeep
@@ -1968,7 +1968,7 @@ def parse_authorized_keys(keystext):
             warn('SSH Protocol 1 keys are ignored: %s' % line)
             continue
         opts = ''
-        if line[0:7] not in ('ssh-dss', 'ssh-rsa'):
+        if line[0:7] not in ('ssh-dss', 'ssh-rsa', 'ssh-ed25519'):
             in_str = False
             in_esc = False
             for i, c in enumerate(line):
@@ -1998,7 +1998,7 @@ def parse_authorized_keys(keystext):
             continue
 
         ssh_type = parts[0]
-        if ssh_type not in ('ssh-dss', 'ssh-rsa'):
+        if ssh_type not in ('ssh-dss', 'ssh-rsa', 'ssh-ed25519'):
             error('Invalid key type "%s", skipping: %s' % (ssh_type, line))
             continue
 


### PR DESCRIPTION
OpenSSH since 6.5 supports [ED25519](http://security.stackexchange.com/questions/50878/ecdsa-vs-ecdh-vs-ed25519-vs-curve25519). DSA keys are being deprecated by newer Linux distros. This PR enables support for ED25519, but doesn't activate it for key generation by default.
