### PR TITLE
Release 1.5.1

### DIFF
--- a/ANNOUNCE
+++ b/ANNOUNCE
@@ -1,28 +1,29 @@
-This is release 1.5.0 of SafeKeep, a centralized and easy to use 
+This is release 1.5.1 of SafeKeep, a centralized and easy to use 
 backup application that combines the best features of a mirror 
 and an incremental backup.
 
-This is a rebase of the source to Python 3, with the same functionality
-as 1.4.5.
+This version is base on Python 3.
 
-Many thanks to all those who sent in bug reports and fixes that made this
-release possible, and to Dimi Paun for his continual work with SafeKeep.
+
+Many thanks to those who sent in bug reports and fixes, especially
+Henrik Riomar that made this release possible, and to Dimi Paun for
+his work with SafeKeep.
 
 Sources and binaries are available from the following locations:
 
-  - RedHat EL/CentOS 8 Fedora 30:
-  http://prdownloads.sourceforge.net/safekeep/safekeep-common-1.5.0-1.noarch.rpm
-  http://prdownloads.sourceforge.net/safekeep/safekeep-client-1.5.0-1.noarch.rpm
-  http://prdownloads.sourceforge.net/safekeep/safekeep-server-1.5.0-1.noarch.rpm
+  - RedHat EL/CentOS 7-8 Fedora 30-34:
+  http://prdownloads.sourceforge.net/safekeep/safekeep-common-1.5.1-1.noarch.rpm
+  http://prdownloads.sourceforge.net/safekeep/safekeep-client-1.5.1-1.noarch.rpm
+  http://prdownloads.sourceforge.net/safekeep/safekeep-server-1.5.1-1.noarch.rpm
  
-  - Ubuntu Trusty Tahr (14.04 LTS) to Cosmic Cuttlefish (18.10):
-  http://prdownloads.sourceforge.net/safekeep/safekeep-common_1.5.0_all.deb
-  http://prdownloads.sourceforge.net/safekeep/safekeep-client_1.5.0_all.deb
-  http://prdownloads.sourceforge.net/safekeep/safekeep-server_1.5.0_all.deb
+  - Ubuntu Trusty Tahr (14.04 LTS) to Groovy Gorilla (20.10):
+  http://prdownloads.sourceforge.net/safekeep/safekeep-common_1.5.1_all.deb
+  http://prdownloads.sourceforge.net/safekeep/safekeep-client_1.5.1_all.deb
+  http://prdownloads.sourceforge.net/safekeep/safekeep-server_1.5.1_all.deb
 
   - Source:
-  http://prdownloads.sourceforge.net/safekeep/safekeep-1.5.0.tar.gz
-  http://prdownloads.sourceforge.net/safekeep/safekeep-1.5.0-1.src.rpm
+  http://prdownloads.sourceforge.net/safekeep/safekeep-1.5.1.tar.gz
+  http://prdownloads.sourceforge.net/safekeep/safekeep-1.5.1-1.src.rpm
 
 The GPG Signing Key can be found in the following location:
 
@@ -36,7 +37,7 @@ uid                  SafeKeep (Signing Key) <safekeep-devel@lists.sourceforge.ne
 sub   1024g/6AA3270F 2012-02-17
 
 NOTE: The minimum version of Python supported is Python 3.4.  If you
-require support of a Python 2, then you should select a release 1.4.5 of
+require support of a Python 2, then you should select release 1.4.5 of
 Safekeep.
 
 To find out more about the project visit on our website:

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ It is build around [**rdiff-backup**](http://www.nongnu.org/rdiff-backup/), enha
 For more information, visit the [project's homepage](http://safekeep.sourceforge.net/) or get in touch [via email](safekeep-devel@lists.sourceforge.net).
 
 # Latest Release
-Version 1.5.0 was released Feb 23, 2019:
+Version 1.5.1 was released Nov 15, 2020:
 
   * **RHEL, CentOS and Fedora**:
-  http://prdownloads.sourceforge.net/safekeep/safekeep-common-1.5.0-1.noarch.rpm
-  http://prdownloads.sourceforge.net/safekeep/safekeep-client-1.5.0-1.noarch.rpm
-  http://prdownloads.sourceforge.net/safekeep/safekeep-server-1.5.0-1.noarch.rpm
+  http://prdownloads.sourceforge.net/safekeep/safekeep-common-1.5.1-1.noarch.rpm
+  http://prdownloads.sourceforge.net/safekeep/safekeep-client-1.5.1-1.noarch.rpm
+  http://prdownloads.sourceforge.net/safekeep/safekeep-server-1.5.1-1.noarch.rpm
 
   * **Ubuntu**:
-  http://prdownloads.sourceforge.net/safekeep/safekeep-common_1.5.0_all.deb
-  http://prdownloads.sourceforge.net/safekeep/safekeep-client_1.5.0_all.deb
-  http://prdownloads.sourceforge.net/safekeep/safekeep-server_1.5.0_all.deb
+  http://prdownloads.sourceforge.net/safekeep/safekeep-common_1.5.1_all.deb
+  http://prdownloads.sourceforge.net/safekeep/safekeep-client_1.5.1_all.deb
+  http://prdownloads.sourceforge.net/safekeep/safekeep-server_1.5.1_all.deb
 
   * **Source**:
-  http://prdownloads.sourceforge.net/safekeep/safekeep-1.5.0.tar.gz
-  http://prdownloads.sourceforge.net/safekeep/safekeep-1.5.0-1.src.rpm
+  http://prdownloads.sourceforge.net/safekeep/safekeep-1.5.1.tar.gz
+  http://prdownloads.sourceforge.net/safekeep/safekeep-1.5.1-1.src.rpm
 

--- a/README_SF_Top
+++ b/README_SF_Top
@@ -19,23 +19,23 @@ Requirements
   * python
   * openssh
 
-Current Release 1.5.0 (23 Feb 2019)
+Current Release 1.5.1 (15 Nov 2020)
 ~~~~~~~~~~~~~~~
 Sources and binaries are available from the following locations:
 
-  - RedHat EL/CentOS 8 Fedora 30:
-  http://prdownloads.sourceforge.net/safekeep/safekeep-common-1.5.0-1.noarch.rpm
-  http://prdownloads.sourceforge.net/safekeep/safekeep-client-1.5.0-1.noarch.rpm
-  http://prdownloads.sourceforge.net/safekeep/safekeep-server-1.5.0-1.noarch.rpm
+  - RedHat EL/CentOS 7-8 Fedora 30-34:
+  http://prdownloads.sourceforge.net/safekeep/safekeep-common-1.5.1-1.noarch.rpm
+  http://prdownloads.sourceforge.net/safekeep/safekeep-client-1.5.1-1.noarch.rpm
+  http://prdownloads.sourceforge.net/safekeep/safekeep-server-1.5.1-1.noarch.rpm
  
-  - Ubuntu Cosmic Cuttlefish (18.10):
-  http://prdownloads.sourceforge.net/safekeep/safekeep-common_1.5.0_all.deb
-  http://prdownloads.sourceforge.net/safekeep/safekeep-client_1.5.0_all.deb
-  http://prdownloads.sourceforge.net/safekeep/safekeep-server_1.5.0_all.deb
+  - Ubuntu Trusty Tahr (14.04 LTS) to Groovy Gorilla (20.10):
+  http://prdownloads.sourceforge.net/safekeep/safekeep-common_1.5.1_all.deb
+  http://prdownloads.sourceforge.net/safekeep/safekeep-client_1.5.1_all.deb
+  http://prdownloads.sourceforge.net/safekeep/safekeep-server_1.5.1_all.deb
 
   - Source:
-  http://prdownloads.sourceforge.net/safekeep/safekeep-1.5.0.tar.gz
-  http://prdownloads.sourceforge.net/safekeep/safekeep-1.5.0-1.src.rpm
+  http://prdownloads.sourceforge.net/safekeep/safekeep-1.5.1.tar.gz
+  http://prdownloads.sourceforge.net/safekeep/safekeep-1.5.1-1.src.rpm
 
 Current GPG Key
 ~~~~~~~~~~~~~~~

--- a/safekeep
+++ b/safekeep
@@ -60,7 +60,7 @@ SSH_STRICT_HOSTKEY_CHECK_OPTS = ['ask', 'yes', 'no' ]
 default_mountoptions = {'xfs' : 'ro,nouuid', 'snapshot' : 'ro', 'bind' : 'ro'}
 
 PROTOCOL = "1.4"
-VERSION = "1.5.0"
+VERSION = "1.5.1"
 VEBOSITY_BY_CLASS = {'DBG': 3, 'INFO': 2, 'WARN': 1, 'ERR': 0}
 
 ######################################################################

--- a/safekeep.spec.in
+++ b/safekeep.spec.in
@@ -107,6 +107,11 @@ id %{name} >/dev/null 2>&1 || \
 %doc samples/sample.backup
 
 %changelog
+* Sun Nov 15 2020 Frank Crawford <frank@crawford.emu.id.au> 1.5.1-1
+  - Add configuration options to handle different versions of rdiff-backup.
+  - Allow specifications of a tempdir.
+  - Minor bugfixes.
+
 * Sat Feb 23 2019 Frank Crawford <frank@crawford.emu.id.au> 1.5.0-1
   - Updated for Python 3
 


### PR DESCRIPTION
  - Add configuration options to handle different versions of rdiff-backup.
  - Allow specifications of a tempdir.
  - Minor bugfixes.